### PR TITLE
Add incident data to show incident page title.

### DIFF
--- a/www/app/views/incidents/show.scala.html
+++ b/www/app/views/incidents/show.scala.html
@@ -6,7 +6,7 @@
   pagerOption: Option[com.gilt.quality.v0.models.MeetingPager]
 )(implicit flash: Flash)
 
-@main(tpl) {
+@main(tpl.copy(title = Some(s"Quality incident #${incident.id}: ${incident.summary}"))) {
 
   @pagerOption.map { pager =>
     <ul class="pager">


### PR DESCRIPTION
Change the incident show page to a dynamic title. Previously was falling back to the default 'quality' title which was ugly!